### PR TITLE
TASK: Fix fetching after many hides and inconsistent state when hiding and saving articles

### DIFF
--- a/src/MainAppRouter.js
+++ b/src/MainAppRouter.js
@@ -26,7 +26,6 @@ import { WEB_READER } from "./reader/ArticleReader";
 import VideoPlayer from "./videos/VideoPlayer";
 import DailyAudioRouter from "./dailyAudio/_DailyAudioRouter";
 import IndividualExercise from "./pages/IndividualExercise";
-import Swiper from "./swiper/Swiper";
 
 export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
   return (
@@ -49,9 +48,7 @@ export default function MainAppRouter({ hasExtension, handleSuccessfulLogIn }) {
       <PrivateRoute path="/select_interests" hasExtension={hasExtension} component={SelectInterests} />
 
       <PrivateRoute path="/exclude_words" hasExtension={hasExtension} component={ExcludeWords} />
-
-      <PrivateRouteWithMainNav path="/articles" component={ArticlesRouter} />
-      <PrivateRouteWithMainNav path="/swiper" component={Swiper} />
+      <PrivateRouteWithMainNav path="/articles/:view?" component={ArticlesRouter} />
       <PrivateRoute path="/watch/video" component={VideoPlayer} />
       <PrivateRouteWithMainNav path="/exercises" component={ExercisesRouter} />
       <PrivateRouteWithMainNav path="/daily-audio" component={DailyAudioRouter} />

--- a/src/articles/ArticlePreview.js
+++ b/src/articles/ArticlePreview.js
@@ -14,10 +14,9 @@ import ArticlePreviewSwipe from "./ArticlePreviewSwipe";
 
 export default function ArticlePreview({
   article,
-  isListView,
+  isListView = true,
   dontShowPublishingTime,
   dontShowSourceIcon,
-  showArticleCompletion,
   hasExtension,
   doNotShowRedirectionModal_UserPreference,
   setDoNotShowRedirectionModal_UserPreference,
@@ -36,10 +35,14 @@ export default function ArticlePreview({
   const [isAnimatingOut, setIsAnimatingOut] = useState(false);
 
   useEffect(() => {
-    if ((article.summary || article.title) && !isTokenizing && !interactiveSummary && !interactiveTitle) {
+      let isMounted = true;
+
+      if ((article.summary || article.title) && !isTokenizing && !interactiveSummary && !interactiveTitle) {
       setIsTokenizing(true);
       api.getArticleSummaryInfo(article.id, (summaryData) => {
-        // Create interactive summary
+          if (!isMounted) return;
+
+          // Create interactive summary
         if (summaryData.tokenized_summary) {
           const interactive = new InteractiveText(
             summaryData.tokenized_summary.tokens,
@@ -73,6 +76,9 @@ export default function ArticlePreview({
         setIsTokenizing(false);
       });
     }
+    return () => {
+          isMounted = false;
+    };
   }, [
     article.summary,
     article.title,
@@ -100,20 +106,6 @@ export default function ArticlePreview({
   function handleOpenRedirectionModal() {
     setIsRedirectionModaOpen(true);
   }
-
-  // function handleHideArticleInListMode() {
-  //   setIsAnimatingOut(true);
-  //   api.hideArticle(article.id, () => {
-  //     // Delay the actual hiding to allow animation to complete
-  //     setTimeout(() => {
-  //       setIsHidden(true);
-  //         if (onArticleHidden) {
-  //             onArticleHidden(article.id);
-  //         }
-  //     }, 300); // Match animation duration
-  //       toast("Article hidden from your feed!");
-  //   });
-  // }
 
   // changed to this --> we should discuss
   function handleHideArticleInListMode() {

--- a/src/articles/ArticleSwipeBrowser.js
+++ b/src/articles/ArticleSwipeBrowser.js
@@ -93,7 +93,6 @@ export default function ArticleSwipeBrowser({
   };
 
   const handleSave = () => {
-    // onArticleSave?.(currentArticle.id);
     const root = hiddenSaveRef.current;
     if (!root) return;
     const clickable = root.querySelector("button, a");

--- a/src/articles/CustomizeFeed.js
+++ b/src/articles/CustomizeFeed.js
@@ -74,7 +74,7 @@ export default function CustomizeFeed({ currentMode = "list" }) {
           )}
           {currentMode === "list" && (
             <s.DropdownItem
-              onClick={() => handleItemClick("/swiper")}
+              onClick={() => handleItemClick("/articles/swiper")}
             >
               <SwipeIcon style={{ fontSize: "1.2em", marginRight: "0.5rem" }} />
               Swipe Mode

--- a/src/articles/OwnArticles.js
+++ b/src/articles/OwnArticles.js
@@ -12,8 +12,8 @@ import useArticlePagination from "../hooks/useArticlePagination";
 
 export default function OwnArticles() {
   const api = useContext(APIContext);
-  const [articleList, setArticleList] = useState(null);
-  const [originalList, setOriginalList] = useState(null);
+  const [articleList, setArticleList] = useState([]);
+  const [originalList, setOriginalList] = useState([]);
 
   function updateOnPagination(newUpdatedList) {
     setArticleList(newUpdatedList);
@@ -36,6 +36,8 @@ export default function OwnArticles() {
     (pageNumber, handleArticleInsertion) => {
       api.getSavedUserArticles(pageNumber, handleArticleInsertion);
     },
+      { skipShouldShow: true }
+
   );
 
   useEffect(() => {

--- a/src/articles/_ArticlesRouter.js
+++ b/src/articles/_ArticlesRouter.js
@@ -1,4 +1,4 @@
-import ArticleListBrowser from "./ArticleListBrowser";
+import {Switch, useLocation} from "react-router-dom";
 import ArticleBrowser from "./ArticleBrowser";
 import BookmarkedArticles from "./BookmarkedArticles";
 import { useContext, useEffect, useState } from "react";
@@ -20,13 +20,20 @@ import { APIContext } from "../contexts/APIContext";
 
 export default function ArticlesRouter({ hasExtension, isChrome }) {
   const api = useContext(APIContext);
-  const [tabsAndLinks, setTabsAndLinks] = useState({
+    const location = useLocation();
+
+    const [tabsAndLinks, setTabsAndLinks] = useState({
     [strings.homeTab]: "/articles",
+    [strings.swipeTab]: "/articles/swiper",
     [strings.search]: "/articles/mySearches",
     [strings.saved]: "/articles/ownTexts",
   });
+  const [articlesAndVideosList, setArticlesAndVideosList] = useState([]);
+  const [originalList, setOriginalList] = useState(null);
+  const isSwipeView = location.pathname === "/articles/swiper";
 
-  useEffect(() => {
+
+    useEffect(() => {
     if (LocalStorage.isStudent()) {
       setTabsAndLinks((prevTabsAndLinks) => ({
         ...prevTabsAndLinks,
@@ -52,27 +59,34 @@ export default function ArticlesRouter({ hasExtension, isChrome }) {
       {/* Rendering top menu first, then routing to corresponding page */}
       <s.NarrowColumn>
         <TopTabs title={strings.articles} tabsAndLinks={tabsAndLinks} />
+          <Switch>
+              <PrivateRoute exact path={["/articles", "/articles/swiper"]}>
+                  <ArticleBrowser
+                      articlesAndVideosList={articlesAndVideosList}
+                      setArticlesAndVideosList={setArticlesAndVideosList}
+                      originalList={originalList}
+                      setOriginalList={setOriginalList}
+                      isSwipeView={isSwipeView}
+                      hasExtension={hasExtension}
+                      isChrome={isChrome}
+                  />
+              </PrivateRoute>
 
-        <PrivateRoute
-          path="/articles"
-          exact
-          component={ArticleBrowser}
-          hasExtension={hasExtension}
-          isChrome={isChrome}
-        />
-        <PrivateRoute path="/articles/bookmarked" component={BookmarkedArticles} />
+              <PrivateRoute path="/articles/bookmarked" component={BookmarkedArticles} />
 
-        <PrivateRoute path="/articles/classroom" component={ClassroomArticles} />
+              <PrivateRoute path="/articles/classroom" component={ClassroomArticles} />
 
-        <PrivateRoute path="/articles/ownTexts" component={OwnArticles} />
+              <PrivateRoute path="/articles/ownTexts" component={OwnArticles} />
 
-        <PrivateRoute path="/articles/forYou" component={RecommendedArticles} />
+              <PrivateRoute path="/articles/forYou" component={RecommendedArticles} />
 
-        <PrivateRoute path="/articles/history" component={ReadingHistory} />
+              <PrivateRoute path="/articles/history" component={ReadingHistory} />
 
-        <PrivateRoute path="/articles/mySearches" component={MySearches} />
+              <PrivateRoute path="/articles/mySearches" component={MySearches} />
 
-        <PrivateRoute path="/search" component={Search} />
+              <PrivateRoute path="/search" component={Search} />
+        </Switch>
+
       </s.NarrowColumn>
     </>
   );

--- a/src/i18n/definitions.js
+++ b/src/i18n/definitions.js
@@ -270,7 +270,7 @@ let strings = new LocalizedStrings(
 
       //ArticleRouter
       homeTab: "Home",
-      // swipeTab: "Swipe",
+      swipeTab: "Swipe",
       classroomTab: "Classroom",
       bookmarkedTab: "Bookmarked",
       saved: "Saves",


### PR DESCRIPTION
TASK: Fix fetching after many hides and inconsistent state when hiding and saving articles

- [x] Sometimes hide does not hide until second time clicked
fixed - state was not updated properly

- [x] Ensure consistent state when switching between the two modes
fixed, moved list states to _ArticlesRouter and made sure both list and swipe shared this. Created new path /articles/swiper and added 'Swipe' to top menu bar

- [x] Ensure all articles are saved properly
confirmed, component OwnArticles adapted to new pagination logic

- [x] Adapt initial fetching to handle cases when many articles are hidden
I have made a quick fix on front-end logic to filter out saved/hidden articles after fetching and then keep re-fetching until list not empty. However this is not a great solution in the long run as the api endpoint needs to be modified to except query parameters to not include hidden or saved articles (must be modified by Zeeguu)